### PR TITLE
Allow Jekyll 4.x

### DIFF
--- a/jekyll_reading_time.gemspec
+++ b/jekyll_reading_time.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r!^exe/!) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "jekyll", "~> 3.5"
+  spec.add_runtime_dependency "jekyll", ">= 3.5"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
Jekyll 4 is to be released, please loosen your Jekyll dependency. 🙏 